### PR TITLE
make routegen work on MacOS

### DIFF
--- a/src/RGEncVideo.cpp
+++ b/src/RGEncVideo.cpp
@@ -249,10 +249,7 @@ void RGEncVideo::browseClicked()
 
 bool RGEncVideo::checkForCodecExecutable(QString &execName)
 {
-#ifdef __linux__
-    //On Linux it should be found in the PATH
-    return !QStandardPaths::findExecutable(execName).isEmpty();
-#else
+#ifdef __WINDOWS__
     QFile codecExec(execName);
     if (!codecExec.exists())
     {
@@ -269,6 +266,9 @@ bool RGEncVideo::checkForCodecExecutable(QString &execName)
     {
         return false;
     }
+#else
+    //On other OS it should be found in the PATH
+    return !QStandardPaths::findExecutable(execName).isEmpty();
 #endif
   return true;
 }

--- a/src/RGSettings.cpp
+++ b/src/RGSettings.cpp
@@ -36,11 +36,11 @@ void RGSettings::setVideoEncoder(const QString &exec)
 QString RGSettings::getVideoEncExec()
 {
   QSettings settings;
-#ifdef __linux__
+#ifdef __WINDOWS__
+  return settings.value("videoEncExec", QDir::currentPath() + "/ffmpeg/bin/ffmpeg.exe").toString();
+#else
   //Always use ffmpeg (assume it's in the PATH)
   return QString("ffmpeg");
-#else
-  return settings.value("videoEncExec", QDir::currentPath() + "/ffmpeg/bin/ffmpeg.exe").toString();
 #endif
 }
 


### PR DESCRIPTION
I just flipped the statements. More OS families are *nix, so primarly check for windows. Works fine with MacOS. See attached binary (darwin ARM64).
With this fix the app can work, as long as ffpmeg is in the path - it is a common way to use homebrew to install ffpmeg, but homebrew does not add the binaries systemwide. So either add the ffpmeg to /etc/paths or run routegen.app from cmd with open routegen.app. This is not ideal to fix it, but makes it at least useable to run routegen on MacOS
[routegen.zip](https://github.com/michjans/routegen/files/10303492/routegen.zip)
